### PR TITLE
Fix Windows-native crash from unconditional resource import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 .env.*
 !.env.example
+.mcp.json
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/

--- a/src/raytsystem/extractors.py
+++ b/src/raytsystem/extractors.py
@@ -4,7 +4,6 @@ import csv
 import io
 import json
 import os
-import resource
 import subprocess
 import sys
 import tempfile
@@ -14,6 +13,11 @@ from dataclasses import dataclass
 from html.parser import HTMLParser
 from pathlib import PurePosixPath
 from typing import Any, ClassVar, Protocol
+
+if sys.platform != "win32":
+    import resource
+else:
+    resource = None  # type: ignore[assignment]
 
 from raytsystem.contracts import (
     ImageLocator,
@@ -464,6 +468,8 @@ class PdfExtractor:
 
     @staticmethod
     def _limit_worker() -> None:
+        if resource is None:
+            return
         limits = (
             (resource.RLIMIT_CPU, 8),
             (resource.RLIMIT_AS, 768 * 1024 * 1024),
@@ -503,7 +509,7 @@ class PdfExtractor:
                     env=environment,
                     timeout=15,
                     check=False,
-                    preexec_fn=self._limit_worker,
+                    preexec_fn=self._limit_worker if resource is not None else None,
                 )
             except (OSError, subprocess.TimeoutExpired) as error:
                 raise ExtractionError("PDF parser worker failed safely") from error


### PR DESCRIPTION
## Summary

- `src/raytsystem/extractors.py` imported the POSIX-only `resource` module unconditionally at module load time, which raises `ModuleNotFoundError` on native Windows and prevented the entire CLI (`raytsystem doctor`, `raytsystem start`, etc.) from running at all.
- `resource` is only used inside `PdfExtractor._limit_worker` to set optional rlimits on the sandboxed PDF-worker subprocess. `preexec_fn` itself isn't supported by `subprocess` on Windows either, so both the import and its one call site are now guarded behind `sys.platform`, following the same pattern already used for the `darwin`-only branch in `control.py`.
- Also added `.mcp.json` to `.gitignore` — it's a local/per-machine MCP server registration file (used to route a Windows host through WSL for POSIX-only functionality) and shouldn't be shared via git.

## Why

Discovered while trying to run raytsystem natively on Windows. This specific crash is a simple, safe compatibility fix; the deeper issue (raytsystem's security-hardened file-access layer in `security/paths.py` relies on POSIX-only `dir_fd`/`O_NOFOLLOW` semantics with no Windows equivalent) is a much larger effort and out of scope for this PR — for now, running raytsystem itself still requires WSL/Linux/macOS. This fix just removes an unnecessary hard crash on import for anyone attempting it.

## Test plan

- [x] Confirmed `import raytsystem.extractors` no longer raises on Windows after the change
- [x] Confirmed `sys.platform == "darwin"`/POSIX behavior is unchanged (import still happens, rlimits still applied, `preexec_fn` still passed)
- [ ] Reviewer: run the existing extractor test suite on Linux/macOS CI to confirm no regression