### PR TITLE
fix: handle Unicode line separators in NativeTextExtractor

### DIFF
--- a/src/raytsystem/extractors.py
+++ b/src/raytsystem/extractors.py
@@ -74,7 +74,7 @@ class NativeTextExtractor:
         spans: list[ExtractedSpan] = []
         character_offset = 0
         for line_number, line_with_ending in enumerate(text.splitlines(keepends=True), 1):
-            excerpt = line_with_ending.rstrip("\n")
+            excerpt = line_with_ending.splitlines()[0] if line_with_ending else ""
             if excerpt.strip():
                 spans.append(
                     ExtractedSpan(


### PR DESCRIPTION
# fix: handle Unicode line separators in NativeTextExtractor

## Summary

Replace `rstrip('\n')` with `splitlines()[0]` (with empty-string guard) in the `NativeTextExtractor.extract` method. This correctly handles Unicode line separators (U+2028, U+2029), form feed, and NEL, which are not removed by `rstrip('\n')` but are considered line boundaries by `str.splitlines()`. Without this change, such characters could appear in extracted excerpts and poison subsequent promotions.

Fixes #20

## Changes

- Modified `src/raytsystem/extractors.py` line 77: 
  - Before: `excerpt = line_with_ending.rstrip("\n")`
  - After: `excerpt = line_with_ending.splitlines()[0] if line_with_ending else ""`

## Testing

Due to sandbox execution restrictions in this environment, the project's test suite could not be executed via `sandbox-run`. However, the change was verified by:
- Inspecting that the replacement is equivalent for ordinary newline (`\n`) and empty lines.
- Confirming that `str.splitlines()` treats all Unicode linebreak characters as boundaries, ensuring U+2028 and U+2029 are stripped from the excerpt.
- Reviewing the rest of the file to ensure no similar issues exist in other extractors.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
