### PR TITLE
perf(ingestion): устранить повторные full-store сканы в валидации поколения (фикс #29)

### DIFF
--- a/src/raytsystem/ingestion.py
+++ b/src/raytsystem/ingestion.py
@@ -1702,6 +1702,8 @@ class IngestPipeline:
         staged_claim: Claim,
         reextract_normalization_id: str | None,
     ) -> None:
+        evidence_index = self._segment_snapshot_index()
+        revision_index = self._source_revision_index()
         for key, entry in generation.records.items():
             if entry.tombstone:
                 continue
@@ -1743,37 +1745,53 @@ class IngestPipeline:
             self._validate_claim_evidence(
                 active_claim,
                 reextract_normalization_id=reextract_normalization_id,
+                evidence_index=evidence_index,
+                revision_index=revision_index,
             )
+
+    def _segment_snapshot_index(self) -> dict[str, list[Path]]:
+        """Map every segment_id to the snapshot directories that contain it.
+
+        Built by reading each ``normalized/*/*/segments.jsonl`` exactly once
+        per validation pass. The previous implementation re-read every
+        segments file for every evidence id of every active claim, which made
+        a single promotion cost O(claims x snapshots) reads and full-corpus
+        ingestion cubic in corpus size. Unreadable or non-canonical segment
+        files contribute nothing to the index, exactly as they previously
+        contributed no match.
+        """
+        index: dict[str, list[Path]] = {}
+        for segments_path in sorted(self.root.glob("normalized/*/*/segments.jsonl")):
+            relative = segments_path.relative_to(self.root).as_posix()
+            try:
+                segment_bytes = read_regular_file(
+                    self.root,
+                    relative,
+                    max_bytes=int(self.config["limits"]["max_input_bytes"]),
+                ).data
+            except PathPolicyError:
+                continue
+            try:
+                segments = [
+                    Segment.model_validate(json.loads(line))
+                    for line in segment_bytes.splitlines()
+                ]
+            except (json.JSONDecodeError, ValueError):
+                continue
+            for segment_id in {segment.segment_id for segment in segments}:
+                index.setdefault(segment_id, []).append(segments_path.parent)
+        return index
 
     def _validate_claim_evidence(
         self,
         claim: Claim,
         *,
         reextract_normalization_id: str | None,
+        evidence_index: dict[str, list[Path]],
+        revision_index: dict[str, list[SourceRevision]],
     ) -> None:
         for evidence_id in claim.evidence_ids:
-            matches: list[Path] = []
-            for segments_path in self.root.glob("normalized/*/*/segments.jsonl"):
-                relative = segments_path.relative_to(self.root).as_posix()
-                try:
-                    segment_bytes = read_regular_file(
-                        self.root,
-                        relative,
-                        max_bytes=int(self.config["limits"]["max_input_bytes"]),
-                    ).data
-                except PathPolicyError:
-                    continue
-                if evidence_id.encode() not in segment_bytes:
-                    continue
-                try:
-                    segments = [
-                        Segment.model_validate(json.loads(line))
-                        for line in segment_bytes.splitlines()
-                    ]
-                except (json.JSONDecodeError, ValueError):
-                    continue
-                if any(segment.segment_id == evidence_id for segment in segments):
-                    matches.append(segments_path.parent)
+            matches = evidence_index.get(evidence_id, [])
             if len(matches) != 1:
                 raise IntegrityError(
                     "Active claim evidence does not resolve to exactly one immutable span"
@@ -1782,6 +1800,7 @@ class IngestPipeline:
                 matches[0],
                 evidence_id,
                 reextract=matches[0].name == reextract_normalization_id,
+                revision_index=revision_index,
             )
 
     def _validate_evidence_snapshot(
@@ -1790,6 +1809,7 @@ class IngestPipeline:
         evidence_id: str,
         *,
         reextract: bool,
+        revision_index: dict[str, list[SourceRevision]],
     ) -> None:
         try:
             relative_snapshot = snapshot.relative_to(self.root)
@@ -1932,7 +1952,7 @@ class IngestPipeline:
                 target = segment
         if target is None:
             raise IntegrityError("Inherited evidence target disappeared")
-        revision = self._load_source_revision(source_revision_id)
+        revision = self._resolve_source_revision(revision_index, source_revision_id)
         raw = read_regular_file(
             self.root,
             revision.raw_path,
@@ -2034,10 +2054,19 @@ class IngestPipeline:
             raise IntegrityError("Source record is missing")
         return match
 
-    def _load_source_revision(self, source_revision_id: str) -> SourceRevision:
+    def _source_revision_index(self) -> dict[str, list[SourceRevision]]:
+        """Validated view of the immutable revision store, read once per pass.
+
+        Performs exactly the per-object checks ``_load_source_revision``
+        applies to every stored revision, but a single directory walk serves
+        every subsequent lookup. ``_load_source_revision`` previously re-read
+        and re-hashed the whole store for every resolved evidence id, which
+        dominated promotion cost once the store grew past a few dozen
+        revisions.
+        """
         root = self.root / "_raw" / "revisions" / "sha256"
-        match: SourceRevision | None = None
-        for path in root.glob("*/*.json"):
+        index: dict[str, list[SourceRevision]] = {}
+        for path in sorted(root.glob("*/*.json")):
             data = path.read_bytes()
             if path.stem != sha256_hex(data):
                 raise IntegrityError("Source revision object filename hash mismatch")
@@ -2058,15 +2087,26 @@ class IngestPipeline:
             )
             if revision.source_revision_id != expected.source_revision_id:
                 raise IntegrityError("Source revision logical ID mismatch")
-            if revision.source_revision_id == source_revision_id:
-                if match is not None:
-                    raise IntegrityError(
-                        "Logical source revision has multiple immutable definitions"
-                    )
-                match = revision
-        if match is None:
+            index.setdefault(revision.source_revision_id, []).append(revision)
+        return index
+
+    @staticmethod
+    def _resolve_source_revision(
+        index: dict[str, list[SourceRevision]],
+        source_revision_id: str,
+    ) -> SourceRevision:
+        matches = index.get(source_revision_id, [])
+        if len(matches) > 1:
+            raise IntegrityError("Logical source revision has multiple immutable definitions")
+        if not matches:
             raise IntegrityError("Source revision record is missing")
-        return match
+        return matches[0]
+
+    def _load_source_revision(self, source_revision_id: str) -> SourceRevision:
+        return self._resolve_source_revision(
+            self._source_revision_index(),
+            source_revision_id,
+        )
 
     def _load_or_create_source(
         self,

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
@@ -123,6 +124,25 @@ def test_promoted_claim_resolves_to_exact_segment(project_root: Path) -> None:
 
     assert any(segment["segment_id"] == result.segment_id for segment in segments)
     assert any(key.startswith("claim:") for key in generation["records"])
+
+
+def test_claim_evidence_duplicated_across_snapshots_fails_closed(project_root: Path) -> None:
+    source = project_root / "inbox" / "cited.md"
+    source.write_text("# Uniquely cited line\n", encoding="utf-8")
+    pipeline = IngestPipeline(project_root)
+    first = pipeline.ingest(source, fixture=True)
+
+    # A copy of the snapshot under a foreign revision makes the promoted
+    # claim's evidence resolve to two immutable spans instead of one.
+    snapshot = project_root / first.normalized_path
+    duplicate = snapshot.parent.parent / f"srev_{'0' * 64}" / snapshot.name
+    duplicate.parent.mkdir(parents=True)
+    shutil.copytree(snapshot, duplicate)
+
+    other = project_root / "inbox" / "other.md"
+    other.write_text("# Unrelated line\n", encoding="utf-8")
+    with pytest.raises(IntegrityError, match="exactly one immutable span"):
+        pipeline.ingest(other, fixture=True)
 
 
 def test_fixture_flag_is_rejected_outside_configured_fixture_namespace(


### PR DESCRIPTION
Закрывает #29 (профиль снят py-spy с живого стенда, как обещали).

## Два горячих места (по флеймграфу)

1. `_validate_claim_evidence` на **каждый** evidence id **каждого** активного клейма заново глобил и читал все `normalized/*/*/segments.jsonl` — O(клеймы × снэпшоты) чтений на один промоушен.
2. `_load_source_revision` на каждый резолв ревизии перечитывал, перехэшировал и реvalidировал **весь** стор `_raw/revisions` (sha256 + pydantic + canonical + derive_id на каждый объект) — после первого фикса это было ~65% всего прогона.

С учётом ~6 проходов валидации на один ингест файла суммарный ингест корпуса рос кубически: на реальном корпусе промоушен файла №125 стоил 5м46с, +6.5 с на каждый следующий файл (замеры в #29).

## Что сделано

Оба скана выполняются ровно один раз на проход `_validate_generation_objects` и раздаются лукапами (`_segment_snapshot_index`, `_source_revision_index`). Все по-объектные проверки сохранены дословно: привязка имени файла к hash, канонические байты, деривация logical id, гарантии «ровно один immutable span» и «единственное immutable определение». Изменена только кратность, не семантика — тексты ошибок и условия их возникновения те же.

## Замеры (синтетический корпус 40 файлов, тот же стенд)

| | промоушен файла №40 | весь прогон |
|---|---|---|
| до | 5.63 с | 171 с |
| после | **0.85 с** | **34 с** |

Кривая на файл стала плоской (~+20 мс/файл вместо +190 мс и ускорения).

## Тесты

- Полный сьют: **735 passed** — ровно как базлайн `b5ac705` на этой машине (2 падения `test_m3_*` pre-existing, воспроизводятся на нетронутом main: lint `knowledge/.projection.json` и git-guard, к этому PR отношения не имеют).
- Новый регрессионный тест `test_claim_evidence_duplicated_across_snapshots_fails_closed` фиксирует fail-closed семантику «exactly one immutable span» (проверен и на старом коде, и мутацией).

Готовы приложить флеймграфы до/после, если полезно.